### PR TITLE
ignore files/directories for workshop

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -1,0 +1,3 @@
+{
+  "excludeItems": ["spec", "Dockerfile", "Gemfile", "Gemfile.lock", "README.md", "body"]
+}


### PR DESCRIPTION
The `workshop.json` file tells Workshop to ignore the files/directories that users don't need.