### PR TITLE
Trim leading and trailing whitespace for HTML/Body spec

### DIFF
--- a/spec/004-html-and-body.rb
+++ b/spec/004-html-and-body.rb
@@ -2,8 +2,8 @@ describe "index.html" do
   let(:index) { File.open("index.html", "rb").read }
 
   it "begins and ends with an html tag" do
-    expect(index.downcase).to start_with("<html>")
-    expect(index.downcase).to end_with("</html>")
+    expect(index.downcase.strip).to start_with("<html>")
+    expect(index.downcase.strip).to end_with("</html>")
   end
 
   it "has a body tag" do


### PR DESCRIPTION
This PR allows whitespace around the `<html>` tags to pass, like so:

```html




<html>
  <body>
    <p>LOL</p>
  </body>
</html>







```

Closes https://github.com/Bloc/workshop/issues/412.