### PR TITLE
Remove period from quotation

### DIFF
--- a/body/003-headers.md
+++ b/body/003-headers.md
@@ -23,4 +23,4 @@ It's not a hard and fast rule, but it keeps the importance of each heading readi
 ### Exercise
 
 1. Open `index.html`
-2. Add an `<h1>` tag at the top of your document, it should read, "Hello World Translations."
+2. Add an `<h1>` tag at the top of your document, it should read, "Hello World Translations".

--- a/body/003-headers.md
+++ b/body/003-headers.md
@@ -23,4 +23,4 @@ It's not a hard and fast rule, but it keeps the importance of each heading readi
 ### Exercise
 
 1. Open `index.html`
-2. Add an `<h1>` tag at the top of your document, it should read, "Hello World Translations".
+2. Add an `<h1>` tag at the top of your document with the text "Hello World Translations".


### PR DESCRIPTION
This caused students to think that the period should be part of the header.