### PR TITLE
move gem dependencies into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM ruby
 VOLUME    ["/data"]
 WORKDIR   /data
 
-ADD Gemfile /data
-ADD Gemfile.lock /data
-
-RUN bundle install
+RUN gem install 'rspec-html-matchers'
+RUN gem install 'css_parser'
+RUN gem install 'pry-nav'
+RUN gem install 'pry-stack_explorer'
 
 # Docker caches ADD directory commands based on directory path.
 # Save this for last so everything above is built from the cache.


### PR DESCRIPTION
Docker's image caching wasn't working, so for students starting the HTML/CSS course it was taking 1-2 minutes to build the image from scratch. Since Dre is still single-threaded, requests from other students were queueing up and taking minutes as well.

This moves all the gem dependencies into the Dockerfile so that Docker's image caching works again.